### PR TITLE
Restart vnf

### DIFF
--- a/vnfm-sdk/build.gradle
+++ b/vnfm-sdk/build.gradle
@@ -16,6 +16,6 @@
  */
 
 dependencies {
-    compile 'org.openbaton:catalogue:5.1.2'
-    compile 'org.openbaton:common:5.1.2'
+    compile 'org.openbaton:catalogue:5.1.4-SNAPSHOT'
+    compile 'org.openbaton:common:5.1.4-SNAPSHOT'
 }


### PR DESCRIPTION
- let the vnfm skip the allocation of the resources if it receives the instantiate message with a non null vnfr

This allows the action "restart vnf" to invoce the instantiate of the VNF without reallocating the resoruces.